### PR TITLE
fix:move prettier

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,7 @@
+{
+    "printWidth": 96,
+    "wrapComments": false,
+    "useModuleLabel": true,
+    "autoGroupImports": "module",
+    "tabWidth": 4
+}

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,5 @@
 {
-    "printWidth": 96,
+    "printWidth": 100,
     "wrapComments": false,
     "useModuleLabel": true,
     "autoGroupImports": "module",

--- a/Move.lock
+++ b/Move.lock
@@ -43,7 +43,7 @@ dependencies = [
 ]
 
 [move.toolchain-version]
-compiler-version = "1.48.0"
+compiler-version = "1.51.1"
 edition = "2024.beta"
 flavor = "sui"
 

--- a/sources/light_client.move
+++ b/sources/light_client.move
@@ -427,7 +427,12 @@ public fun calc_next_required_difficulty(lc: &LightClient, parent_block: &LightB
     let first_timestamp = first_header.timestamp() as u64;
     let last_timestamp = parent_block.header().timestamp() as u64;
 
-    let new_target = retarget_algorithm(params, previous_target, first_timestamp, last_timestamp);
+    let new_target = retarget_algorithm(
+        params,
+        previous_target,
+        first_timestamp,
+        last_timestamp,
+    );
     let new_bits = target_to_bits(new_target);
     new_bits
 }

--- a/tests/difficulty_tests.move
+++ b/tests/difficulty_tests.move
@@ -105,7 +105,10 @@ fun difficulty_computation_mainnet_happy_cases() {
     lc.set_block_hash_by_height(first_block.height(), first_block.header().block_hash());
     lc.append_block(first_block);
 
-    let new_bits = calc_next_required_difficulty(&lc, lc.get_light_block_by_hash(last_block_hash));
+    let new_bits = calc_next_required_difficulty(
+        &lc,
+        lc.get_light_block_by_hash(last_block_hash),
+    );
 
     // 0x1703098c is bits of block 860832
     assert_eq!(new_bits, 0x1703098c);


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
<!-- markdownlint-disable MD012 -->

## Description

Closes: #XXXX

---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
    <!-- * `feat`: A new feature
    * `fix`: A bug fix
    * `docs`: Documentation only changes
    * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
    * `refactor`: A code change that neither fixes a bug nor adds a feature
    * `perf`: A code change that improves performance
    * `test`: Adding missing tests or correcting existing tests
    * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
    * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
    * `chore`: Other changes that don't modify src or test files
    * `revert`: Reverts a previous commit -->
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] added appropriate labels to the PR
- [ ] provided a link to the relevant issue or specification
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included doc comments for public functions
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary

## Summary by Sourcery

Add Prettier configuration for Move files and apply formatting changes

Enhancements:
- Introduce a .prettierrc file to enable consistent Prettier formatting for Move code

Chores:
- Reformat function calls in Move source and test files to match Prettier style
- Update Move.lock to reflect the formatting changes