### PR TITLE
feat: add support for encodedSK

### DIFF
--- a/scripts/new_light_client.js
+++ b/scripts/new_light_client.js
@@ -1,4 +1,4 @@
-import { fromHex } from "@mysten/sui/utils";
+import { fromHex, fromBase64 } from "@mysten/sui/utils";
 import { getFullnodeUrl, SuiClient } from "@mysten/sui/client";
 import { Transaction } from "@mysten/sui/transactions";
 import { Ed25519Keypair } from "@mysten/sui/keypairs/ed25519";
@@ -6,7 +6,16 @@ import { Ed25519Keypair } from "@mysten/sui/keypairs/ed25519";
 import "dotenv/config";
 
 function loadSigner() {
-	return Ed25519Keypair.deriveKeypair(process.env.MNEMONIC);
+	if (process.env.ENCODE_SK) {
+		let sk = fromBase64(process.env.ENCODE_SK);
+		return Ed25519Keypair.fromSecretKey(sk.slice(1));
+	}
+	if (process.env.MNEMONIC) {
+		return Ed25519Keypair.deriveKeypair(process.env.MNEMONIC);
+	}
+	throw new Error(
+		"Missing required environment variable: Please set either ENCODE_SK or MNEMONIC."
+	);
 }
 
 async function main() {


### PR DESCRIPTION
## Description

Closes: #XXXX

---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
    <!-- * `feat`: A new feature
    * `fix`: A bug fix
    * `docs`: Documentation only changes
    * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
    * `refactor`: A code change that neither fixes a bug nor adds a feature
    * `perf`: A code change that improves performance
    * `test`: Adding missing tests or correcting existing tests
    * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
    * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
    * `chore`: Other changes that don't modify src or test files
    * `revert`: Reverts a previous commit -->
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] added appropriate labels to the PR
- [ ] provided a link to the relevant issue or specification
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included doc comments for public functions
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary

## Summary by Sourcery

Add support for loading an Ed25519 keypair from a Base64-encoded secret key via the ENCODE_SK environment variable, falling back to MNEMONIC and throwing an error if neither is provided.

New Features:
- Enable keypair loading from ENCODE_SK Base64 secret key
- Retain existing mnemonic-based keypair derivation as a fallback
- Throw a descriptive error when neither ENCODE_SK nor MNEMONIC is set