### PR TITLE
feat(btc_parser): taproot  output verification

### DIFF
--- a/packages/btc_parser/sources/output.move
+++ b/packages/btc_parser/sources/output.move
@@ -8,6 +8,7 @@ use btc_parser::vector_utils::vector_slice;
 // === BTC script opcodes ===
 /// An empty array of bytes is pushed onto the stack. (This is not a no-op: an item is added to the stack.)
 const OP_0: u8 = 0x00;
+const OP_1: u8 = 0x01;
 /// Duplicates the top stack item
 const OP_DUP: u8 = 0x76;
 /// Pop the top stack item and push its RIPEMD(SHA256(top item)) hash
@@ -98,6 +99,13 @@ public fun is_P2WPHK(output: &Output): bool {
         script[1] == OP_DATA_20
 }
 
+public fun is_taproot(output: &Output): bool {
+    let script = output.script_pubkey;
+    script.length() == 34 &&
+	script[0] == OP_1 &&
+	script[1] == OP_DATA_32
+}
+
 // TODO: add support script addresses.
 // TODO: check and verify the address to make sure we support it. Return error otherwise
 /// extracts public key hash (PKH) from the output in P2PHK or P2WPKH
@@ -124,6 +132,15 @@ public fun extract_script_hash(output: &Output): Option<vector<u8>> {
 public fun extract_witness_script_hash(output: &Output): Option<vector<u8>> {
     let script = output.script_pubkey;
     if (output.is_P2WSH()) {
+        option::some(vector_slice(&script, 2, 34))
+    } else {
+        option::none()
+    }
+}
+
+public fun extract_taproot(output: &Output): Option<vector<u8>> {
+    let script = output.script_pubkey;
+    if (output.is_taproot()) {
         option::some(vector_slice(&script, 2, 34))
     } else {
         option::none()

--- a/packages/btc_parser/sources/output.move
+++ b/packages/btc_parser/sources/output.move
@@ -8,7 +8,7 @@ use btc_parser::vector_utils::vector_slice;
 // === BTC script opcodes ===
 /// An empty array of bytes is pushed onto the stack. (This is not a no-op: an item is added to the stack.)
 const OP_0: u8 = 0x00;
-const OP_1: u8 = 0x01;
+const OP_1: u8 = 0x51;
 /// Duplicates the top stack item
 const OP_DUP: u8 = 0x76;
 /// Pop the top stack item and push its RIPEMD(SHA256(top item)) hash

--- a/packages/btc_parser/tests/output_tests.move
+++ b/packages/btc_parser/tests/output_tests.move
@@ -86,3 +86,22 @@ fun P2WHS_happy_cases() {
     assert_eq!(output.is_P2WSH(), false);
     assert_eq!(output.extract_witness_script_hash(), option::none());
 }
+
+#[test]
+fun taproot_happy_cases() {
+    let output =
+        &output::new(100, x"51200f0c8db753acbd17343a39c2f3f4e35e4be6da749f9e35137ab220e7b238a667");
+    assert_eq!(output.is_taproot(), true);
+    assert_eq!(
+        output.extract_witness_script_hash(),
+        option::some(x"0f0c8db753acbd17343a39c2f3f4e35e4be6da749f9e35137ab220e7b238a667"),
+    );
+    // add 00 to script
+    let output =
+        &output::new(
+            100,
+            x"0051200f0c8db753acbd17343a39c2f3f4e35e4be6da749f9e35137ab220e7b238a667",
+        );
+    assert_eq!(output.is_P2WSH(), false);
+    assert_eq!(output.extract_witness_script_hash(), option::none());
+}

--- a/packages/btc_parser/tests/output_tests.move
+++ b/packages/btc_parser/tests/output_tests.move
@@ -93,7 +93,7 @@ fun taproot_happy_cases() {
         &output::new(100, x"51200f0c8db753acbd17343a39c2f3f4e35e4be6da749f9e35137ab220e7b238a667");
     assert_eq!(output.is_taproot(), true);
     assert_eq!(
-        output.extract_witness_script_hash(),
+        output.extract_taproot(),
         option::some(x"0f0c8db753acbd17343a39c2f3f4e35e4be6da749f9e35137ab220e7b238a667"),
     );
     // add 00 to script

--- a/packages/btc_parser/tests/output_tests.move
+++ b/packages/btc_parser/tests/output_tests.move
@@ -102,6 +102,6 @@ fun taproot_happy_cases() {
             100,
             x"0051200f0c8db753acbd17343a39c2f3f4e35e4be6da749f9e35137ab220e7b238a667",
         );
-    assert_eq!(output.is_P2WSH(), false);
+    assert_eq!(output.is_taproot(), false);
     assert_eq!(output.extract_witness_script_hash(), option::none());
 }

--- a/packages/btc_parser/tests/tx_tests.move
+++ b/packages/btc_parser/tests/tx_tests.move
@@ -54,6 +54,20 @@ fun segwit_tx_01() {
 }
 
 #[test]
+fun taproot_tx_parse_happy_cases() {
+    // https://learnmeabitcoin.com/explorer/tx/a7115c7267dbb4aab62b37818d431b784fe731f4d2f9fa0939a9980d581690ec
+    let data =
+        x"020000000001014f75f3f02692ad2c67d02b272e5336017a4116b9efa47b9cc46514312c8ef5170000000000fdffffff02204e0000000000002251200f0c8db753acbd17343a39c2f3f4e35e4be6da749f9e35137ab220e7b238a6674c3001000000000016001453d9c40342ee880e766522c3e2b854d37f2b3cbf0247304402200ea17ab567125d0d724035f910ff43dab3544e3a9f327bde081b8737345376cf022062d073d84a4382ae55b409744f8c2a1bbf85924a452f982fcb0dcacebbdb06d901210315ece6df13fe80219f36187a5f884893897bd5c39bff6ccf4377d7a07c731ed9ff260d00";
+    let mut r = reader::new(data);
+    let txn = tx::deserialize(&mut r);
+    assert_eq!(txn.tx_id(), x"ec9016580d98a93909faf9d2f431e74f781b438d81372bb6aab4db67725c11a7");
+    assert_eq!(txn.inputs().length(), 1);
+    assert_eq!(txn.outputs().length(), 2);
+    assert_eq!(txn.is_witness(), true);
+    assert_eq!(txn.output_at(0).is_taproot(), true);
+}
+
+#[test]
 fun coinbase_logic() {
     // https://learnmeabitcoin.com/explorer/tx/66318604a7123c8ab607108400815cde7a22475d305da03be3d3bf8a3a5a4606
     let raw_coinbase_tx =


### PR DESCRIPTION
## Description

Closes: #XXXX

---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
    <!-- * `feat`: A new feature
    * `fix`: A bug fix
    * `docs`: Documentation only changes
    * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
    * `refactor`: A code change that neither fixes a bug nor adds a feature
    * `perf`: A code change that improves performance
    * `test`: Adding missing tests or correcting existing tests
    * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
    * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
    * `chore`: Other changes that don't modify src or test files
    * `revert`: Reverts a previous commit -->
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] added appropriate labels to the PR
- [ ] provided a link to the relevant issue or specification
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included doc comments for public functions
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary

## Summary by Sourcery

Enable Taproot output support in btc_parser by adding OP_1 opcode, is_taproot and extract_taproot functions, and covering them with unit and integration tests.

New Features:
- Support Taproot output detection via is_taproot function
- Support Taproot script hash extraction via extract_taproot function
- Introduce OP_1 opcode constant for Taproot script parsing

Tests:
- Add unit tests for Taproot output parsing in output_tests.move
- Add transaction-level test for Taproot output in tx_tests.move