### PR TITLE
feat(bitcoin_spv): use bitwise_not for ~ operation. 

### DIFF
--- a/packages/bitcoin_spv/sources/block_header.move
+++ b/packages/bitcoin_spv/sources/block_header.move
@@ -72,11 +72,10 @@ public fun calc_work(header: &BlockHeader): u256 {
     // or ~bnTarget / (bnTarget+1) + 1.
     // More information: https://github.com/bitcoin/bitcoin/blob/28.x/src/chain.cpp#L139.
     //
-    // A move language doesn't support ~ operator. However, we have 2**256 - 1 = 2**255 - 1 + 2*255;
-    // so we have formula bellow:
+
     let target = header.target();
-    let n255 = 1 << 255;
-    (n255 - 1 - target + n255) / (target + 1) + 1
+
+    (target.bitwise_not() / (target + 1)) + 1
 }
 
 /// checks if the block headers meet PoW target requirements. Panics otherewise.


### PR DESCRIPTION
## Description

Use bitwise_not for ~ operation
---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
    <!-- * `feat`: A new feature
    * `fix`: A bug fix
    * `docs`: Documentation only changes
    * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
    * `refactor`: A code change that neither fixes a bug nor adds a feature
    * `perf`: A code change that improves performance
    * `test`: Adding missing tests or correcting existing tests
    * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
    * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
    * `chore`: Other changes that don't modify src or test files
    * `revert`: Reverts a previous commit -->
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] added appropriate labels to the PR
- [ ] provided a link to the relevant issue or specification
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included doc comments for public functions
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary

## Summary by Sourcery

Enhancements:
- Refactor calc_work to use bitwise_not instead of manual formula for bitwise NOT