### PR TITLE
refactor: deduplicate header parsing code

### DIFF
--- a/packages/bitcoin_spv/Move.lock
+++ b/packages/bitcoin_spv/Move.lock
@@ -2,13 +2,14 @@
 
 [move]
 version = 3
-manifest_digest = "5DDDA30A8FB3D16364B14BFBB2E60ED111AAB91CB5324AF796524D6E3DE6AACE"
-deps_digest = "F9B494B64F0615AED0E98FC12A85B85ECD2BC5185C22D30E7F67786BB52E507C"
+manifest_digest = "CBE91C755917E43393830CE7E9405A00DC2696F1601C72492AB8494857FD95B6"
+deps_digest = "397E6A9F7A624706DBDFEE056CE88391A15876868FD18A88504DA74EB458D697"
 dependencies = [
   { id = "Bridge", name = "Bridge" },
   { id = "MoveStdlib", name = "MoveStdlib" },
   { id = "Sui", name = "Sui" },
   { id = "SuiSystem", name = "SuiSystem" },
+  { id = "btc_parser", name = "btc_parser" },
 ]
 
 [[move.package]]
@@ -40,6 +41,17 @@ source = { git = "https://github.com/MystenLabs/sui.git", rev = "db951a5ea6b125f
 dependencies = [
   { id = "MoveStdlib", name = "MoveStdlib" },
   { id = "Sui", name = "Sui" },
+]
+
+[[move.package]]
+id = "btc_parser"
+source = { local = "../btc_parser" }
+
+dependencies = [
+  { id = "Bridge", name = "Bridge" },
+  { id = "MoveStdlib", name = "MoveStdlib" },
+  { id = "Sui", name = "Sui" },
+  { id = "SuiSystem", name = "SuiSystem" },
 ]
 
 [move.toolchain-version]

--- a/packages/bitcoin_spv/Move.toml
+++ b/packages/bitcoin_spv/Move.toml
@@ -8,7 +8,7 @@ authors = ["Native"]
 # For remote import, use the `{ git = "...", subdir = "...", rev = "..." }`.
 # Revision can be a branch, a tag, and a commit hash.
 # For local dependencies use `local = path`. Path is relative to the package root
-# Local = { local = "../path/to" }
+btc_parser = { local = "../btc_parser" }
 
 # To resolve a version conflict and force a specific version for dependency
 # override use `override = true`

--- a/packages/bitcoin_spv/sources/light_block.move
+++ b/packages/bitcoin_spv/sources/light_block.move
@@ -2,7 +2,7 @@
 
 module bitcoin_spv::light_block;
 
-use bitcoin_spv::block_header::BlockHeader;
+use bitcoin_spv::header::BlockHeader;
 
 public struct LightBlock has copy, drop, store {
     height: u64,

--- a/packages/bitcoin_spv/sources/light_client.move
+++ b/packages/bitcoin_spv/sources/light_client.move
@@ -2,14 +2,20 @@
 
 module bitcoin_spv::light_client;
 
-use bitcoin_spv::block_header::BlockHeader;
+use bitcoin_spv::block_header::{calc_work, pow_check, target};
 use bitcoin_spv::btc_math::target_to_bits;
 use bitcoin_spv::light_block::{LightBlock, new_light_block};
 use bitcoin_spv::merkle_tree::verify_merkle_proof;
 use bitcoin_spv::params::{Self, Params, is_correct_init_height};
 use bitcoin_spv::utils::nth_element;
+use btc_parser::header::BlockHeader;
 use sui::event;
 use sui::table::{Self, Table};
+
+// alias methods
+use fun calc_work as BlockHeader.calc_work;
+use fun pow_check as BlockHeader.pow_check;
+use fun target as BlockHeader.target;
 
 /// Package version
 const VERSION: u32 = 1;

--- a/packages/bitcoin_spv/tests/block_header_tests.move
+++ b/packages/bitcoin_spv/tests/block_header_tests.move
@@ -3,36 +3,21 @@
 #[test_only]
 module bitcoin_spv::block_header_tests;
 
-use bitcoin_spv::block_header::{new_block_header, EPoW, EInvalidBlockHeaderSize};
-use bitcoin_spv::btc_math::to_u32;
+use bitcoin_spv::block_header::{EPoW, calc_work, pow_check, target};
+use btc_parser::header::{Self, BlockHeader};
 use std::unit_test::assert_eq;
 
-#[test]
-fun block_header_happy_case() {
-    // data get from block 0000000000000000000293bf6e86820d867cc4ca13cd98326af85bb3bebab9ac from mainnet
-    // or block 794143
-    let raw_header =
-        x"000080200e102b98a160f4416c8ff0198db9b177523525c9de8a000000000000000000003b9b941003024e1afa90199732fdb1366a122ab0a5cacd3f7bcb8cb8815a811b560e8864697e051767c0c9fd";
-    let header = new_block_header(raw_header);
+use fun calc_work as BlockHeader.calc_work;
+use fun pow_check as BlockHeader.pow_check;
+use fun target as BlockHeader.target;
 
-    // verify data extract from header
-    assert_eq!(header.version(), to_u32(x"00008020"));
-    assert_eq!(
-        header.parent(),
-        x"0e102b98a160f4416c8ff0198db9b177523525c9de8a00000000000000000000",
-    );
-    assert_eq!(
-        header.merkle_root(),
-        x"3b9b941003024e1afa90199732fdb1366a122ab0a5cacd3f7bcb8cb8815a811b",
-    );
-    assert_eq!(header.timestamp(), to_u32(x"560e8864"));
-    assert_eq!(header.bits(), to_u32(x"697e0517"));
-    assert_eq!(header.nonce(), to_u32(x"67c0c9fd"));
-    assert_eq!(
-        header.block_hash(),
-        x"acb9babeb35bf86a3298cd13cac47c860d82866ebf9302000000000000000000",
+#[test]
+fun calc_work_and_target_happy_cases() {
+    let header = header::new(
+        x"000080200e102b98a160f4416c8ff0198db9b177523525c9de8a000000000000000000003b9b941003024e1afa90199732fdb1366a122ab0a5cacd3f7bcb8cb8815a811b560e8864697e051767c0c9fd",
     );
     assert_eq!(header.calc_work(), 220053167595535890616746);
+    assert_eq!(header.target(), 526200511006255617572972890856003254679941608705622016);
 }
 
 #[test]
@@ -46,7 +31,7 @@ fun pow_check_happy_cases() {
     //     "difficulty_target": "ffff001d",
     //     "nonce": "21e05e45"
     // }
-    let header = new_block_header(
+    let header = header::new(
         x"01000000cb60e68ead74025dcfd4bf4673f3f71b1e678be9c6e6585f4544c79900000000c7f42be7f83eddf2005272412b01204352a5fddbca81942c115468c3c4ec2fff827ad949ffff001d21e05e45",
     );
     header.pow_check();
@@ -60,7 +45,7 @@ fun pow_check_happy_cases() {
     //     "difficulty_target": "ffff001d",
     //     "nonce": "1dac2b7c"
     // }
-    let header = new_block_header(
+    let header = header::new(
         x"0100000000000000000000000000000000000000000000000000000000000000000000003ba3edfd7a7b12b27ac72c3e67768f617fc81bc3888a51323a9fb8aa4b1e5e4a29ab5f49ffff001d1dac2b7c",
     );
     header.pow_check();
@@ -70,20 +55,8 @@ fun pow_check_happy_cases() {
 #[expected_failure(abort_code = EPoW)] // ENotFound is a constant defined in the module
 fun pow_check_on_header_not_satisfy_pow_should_fail() {
     // we get block header from https://learnmeabitcoin.com/explorer/block/000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f. However, we set nonce = 0x00000000 which is make pow_check failed
-    let header = new_block_header(
+    let header = header::new(
         x"0100000000000000000000000000000000000000000000000000000000000000000000003ba3edfd7a7b12b27ac72c3e67768f617fc81bc3888a51323a9fb8aa4b1e5e4a29ab5f49ffff001d00000000",
     );
     header.pow_check();
-}
-
-#[test, expected_failure(abort_code = EInvalidBlockHeaderSize)]
-fun block_header_size_too_short_should_fail() {
-    new_block_header(x"0123456789abcdef");
-}
-
-#[test, expected_failure(abort_code = EInvalidBlockHeaderSize)]
-fun block_header_size_too_long_should_fail() {
-    new_block_header(
-        x"0100000000000000000000000000000000000000000000000000000000000000000000003ba3edfd7a7b12b27ac72c3e67768f617fc81bc3888a51323a9fb8aa4b1e5e4a29ab5f49ffff001d00000000ffff",
-    );
 }

--- a/packages/bitcoin_spv/tests/difficulty_tests.move
+++ b/packages/bitcoin_spv/tests/difficulty_tests.move
@@ -3,7 +3,6 @@
 #[test_only]
 module bitcoin_spv::difficulty_test;
 
-use bitcoin_spv::block_header::new_block_header;
 use bitcoin_spv::btc_math::{bits_to_target, target_to_bits};
 use bitcoin_spv::light_block::new_light_block;
 use bitcoin_spv::light_client::{
@@ -12,6 +11,7 @@ use bitcoin_spv::light_client::{
     calc_next_required_difficulty
 };
 use bitcoin_spv::params;
+use btc_parser::header;
 use std::unit_test::assert_eq;
 use sui::test_scenario;
 
@@ -67,7 +67,7 @@ fun difficulty_computation_mainnet_happy_cases() {
         params::mainnet(),
         0,
         vector[
-            new_block_header(
+            header::new(
                 x"0100000000000000000000000000000000000000000000000000000000000000000000003ba3edfd7a7b12b27ac72c3e67768f617fc81bc3888a51323a9fb8aa4b1e5e4a29ab5f49ffff001d1dac2b7c",
             ),
         ],
@@ -86,7 +86,7 @@ fun difficulty_computation_mainnet_happy_cases() {
     // check retarget difficulty
     // bits = 5b250317 # little endian
     // timestamp = b806e166 # little endian
-    let header = new_block_header(
+    let header = header::new(
         x"0040a320aa52a8971f61e56bf5a45117e3e224eabfef9237cb9a0100000000000000000060a9a5edd4e39b70ee803e3d22673799ae6ec733ea7549442324f9e3a790e4e4b806e1665b250317807427ca",
     );
     let last_block = new_light_block(
@@ -100,7 +100,7 @@ fun difficulty_computation_mainnet_happy_cases() {
     lc.append_block(last_block);
 
     // timestamp = db34cf66
-    let header = new_block_header(
+    let header = header::new(
         x"0060b0329fd61df7a284ba2f7debbfaef9c5152271ef8165037300000000000000000000562139850fcfc2eb3204b1e790005aaba44e63a2633252fdbced58d2a9a87e2cdb34cf665b250317245ddc6a",
     );
     let first_block = new_light_block(858816, header, 0);
@@ -129,7 +129,7 @@ fun difficulty_computation_regtest_happy_case() {
         // NOTE: this is random header and when compute a new target in regtest mode this always returns a constant
         // this is power_limit.
         vector[
-            new_block_header(
+            header::new(
                 x"0040a320aa52a8971f61e56bf5a45117e3e224eabfef9237cb9a0100000000000000000060a9a5edd4e39b70ee803e3d22673799ae6ec733ea7549442324f9e3a790e4e4b806e1665b250317807427ca",
             ),
         ],

--- a/packages/bitcoin_spv/tests/fork_tests.move
+++ b/packages/bitcoin_spv/tests/fork_tests.move
@@ -3,7 +3,7 @@
 #[test_only]
 module bitcoin_spv::handle_fork_tests;
 
-use bitcoin_spv::block_header::{new_block_header, BlockHeader};
+use bitcoin_spv::header::{Self, BlockHeader};
 use bitcoin_spv::light_client::{
     LightClient,
     new_light_client,
@@ -46,7 +46,7 @@ fun new_lc_for_test(ctx: &mut TxContext): (LightClient, vector<BlockHeader>) {
         x"000000304f58550f49b5c9dce6328bc8d7b8f5941823efcc51741a024c17d9745ba21111cb2db51b4bf0858c2318820adafa1c8640703dca1faceea0205f388f160d452539c5b167ffff7f2004000000",
         x"00000030aa8bd6ce82edf1f9c03abc2243281f622594bc3aec5106a17f612371f76060084e05aaf29bda3424553cb4636006d006030690b91875fe96fdb4c52d4a38ba8a39c5b167ffff7f2003000000",
         x"0000003040ce8b407650044a4294fd43c6d78cbb4f78ac98527f858f3950dad92fc5982ddebd5d70e4be4f6f5cc474416137a697f1fca22bf87e9066eb9b43dd7882d23239c5b167ffff7f2002000000",
-    ].map!(|h| new_block_header(h));
+    ].map!(|h| header::new(h));
 
     let lc = new_light_client(params::regtest(), 0, headers, 0, 8, ctx);
 
@@ -73,7 +73,7 @@ fun insert_headers_switch_fork_tests() {
         x"000000307370f207ef4945a89b10b1c60a14770136109de093df4544340251190a5c2436494bba4bf2f3dc3a1d8c1bb592eeadc16c77b6bdd42c6ad2003a704641c3caeb9dc5b167ffff7f2000000000",
     ];
 
-    let headers = raw_headers.map!(|h| new_block_header(h));
+    let headers = raw_headers.map!(|h| header::new(h));
 
     // calc_work = 1 for each block header
     // Fork visualization:
@@ -127,7 +127,7 @@ fun insert_headers_fork_not_enought_power_should_fail() {
         x"000000309c32ae8f3b099ea17563bb425476cf962b84269e09d17e19350b819695970f2cdebd5d70e4be4f6f5cc474416137a697f1fca22bf87e9066eb9b43dd7882d2329dc5b167ffff7f2001000000",
     ];
 
-    let headers = raw_headers.map!(|h| new_block_header(h));
+    let headers = raw_headers.map!(|h| header::new(h));
     // calc_work = 1 for each block header
     // Fork visualization:
     // H0->...->H12->H13->H13->H15->H16->H17
@@ -148,7 +148,7 @@ fun insert_headers_block_does_not_exist_should_fail() {
     let raw_headers = vector[
         x"00000030db0338a432b1242c3bd22c245583e31788feaa6cb189673877b92f2a34eaf4606be46c161e69696c1c83ba3a1ea52f071fcdada5a6bce28f5da591b969b42da19dc5b167ffff7f2001000000",
     ];
-    let headers = raw_headers.map!(|h| new_block_header(h));
+    let headers = raw_headers.map!(|h| header::new(h));
     let sender = @0x01;
     let mut scenario = test_scenario::begin(sender);
     let ctx = scenario.ctx();
@@ -211,7 +211,7 @@ fun reorg_happy_case() {
         x"040000000217ca583ab80b6eda0cc99e814b2aa9750497de8e98901f5cfc76235f4e7365db612186fbd125fd83a05d9ccd75a5abf6453cd60e69b5d6e623e782d8e390b66b148653ffff7f20f4ffffef",
         x"04000000cd61864c5790c7903f049f6f2247eb961f492c09a1c17ebec52a7e22a10a1d41f1d563bcbebd74d8bf517b1021ebaef7b9beb24c376fd6f1d695383b5fd4a86216178653ffff7f2002000000",
         x"0400000048e30418dc91e17527e7b169aba58331e5627a4a1b434295149442fcb779040030128d2428f272019fd5047fef2eb5e74f60c360bd6c26603df7e1bc8a54a08058188653ffff7f20f3ffffef",
-    ].map!(|h| new_block_header(h));
+    ].map!(|h| header::new(h));
 
     // bits at height 0 always equal power_limit_bits
     // so we start at height 1 for easy testing.
@@ -244,7 +244,7 @@ fun reorg_happy_case() {
         x"0400000061f68cf3904a77101fe0a41cfc605d40564bdf693712a8684fded6b01b7ecb5ca8f039285b833d6c93e42d714669e90de06c143d11fba13cd66e1f2735eb219b302e8653ffff7f20f2ffffef",
     ];
 
-    let forks = raw_forks.map!(|f| new_block_header(f));
+    let forks = raw_forks.map!(|f| header::new(f));
     // Fork visualization:
     // H0->H1->H2->H3->H4->...->H9: chain_work = 22
     //             | ->F0->...->F15: chain_work = 42

--- a/packages/bitcoin_spv/tests/light_client_tests.move
+++ b/packages/bitcoin_spv/tests/light_client_tests.move
@@ -3,7 +3,6 @@
 #[test_only]
 module bitcoin_spv::light_client_tests;
 
-use bitcoin_spv::block_header::new_block_header;
 use bitcoin_spv::light_block::new_light_block;
 use bitcoin_spv::light_client::{
     insert_header,
@@ -18,6 +17,7 @@ use bitcoin_spv::light_client::{
     EAlreadyUpdated
 };
 use bitcoin_spv::params;
+use btc_parser::header::{Self, BlockHeader};
 use std::unit_test::{assert_eq, assert_ref_eq};
 use sui::test_scenario;
 
@@ -125,7 +125,7 @@ fun new_lc_for_test(ctx: &mut TxContext): LightClient {
         // }
         x"0060b0329fd61df7a284ba2f7debbfaef9c5152271ef8165037300000000000000000000562139850fcfc2eb3204b1e790005aaba44e63a2633252fdbced58d2a9a87e2cdb34cf665b250317245ddc6a",
     ];
-    let headers = raw_headers.map!(|h| new_block_header(h));
+    let headers = raw_headers.map!(|h| header::new(h));
     new_light_client(params::mainnet(), start_block, headers, 0, 8, ctx)
 }
 
@@ -140,7 +140,7 @@ fun init_light_client_wrong_start_height_should_fail() {
         x"00a0b434e99097082da749068bd8cc81f7ddd017f3153e1f25b000000000000000000000fbef99870f826601fed79703773deb9122f03b5167c0b7554c00112f9fa99e171320cf66763d03175c560dcc",
         x"00205223ce8791e22d0a1b64cfb0b485af2ddba566cb54292e0c030000000000000000003f5d648740a3a0519c56fce7f230d4c35aa83c9df0478b77be3fc89f0acfb8cc9524cf66763d03171746f213",
     ];
-    let headers = raw_headers.map!(|h| new_block_header(h));
+    let headers = raw_headers.map!(|h| header::new(h));
 
     initialize_light_client(0, height, headers, 0, 8, ctx);
     scenario.end();
@@ -157,7 +157,7 @@ fun init_light_client_happy_case() {
         x"00a0b434e99097082da749068bd8cc81f7ddd017f3153e1f25b000000000000000000000fbef99870f826601fed79703773deb9122f03b5167c0b7554c00112f9fa99e171320cf66763d03175c560dcc",
         x"00205223ce8791e22d0a1b64cfb0b485af2ddba566cb54292e0c030000000000000000003f5d648740a3a0519c56fce7f230d4c35aa83c9df0478b77be3fc89f0acfb8cc9524cf66763d03171746f213",
     ];
-    let headers = raw_headers.map!(|h| new_block_header(h));
+    let headers = raw_headers.map!(|h| header::new(h));
     initialize_light_client(0, height, headers, 0, 8, ctx);
     scenario.end();
 }
@@ -176,7 +176,7 @@ fun test_set_get_block_happy_case() {
     //     "difficulty_target": "5b250317",
     //     "nonce": "245ddc6a"
     // }
-    let header = new_block_header(
+    let header = header::new(
         x"0060b0329fd61df7a284ba2f7debbfaef9c5152271ef8165037300000000000000000000562139850fcfc2eb3204b1e790005aaba44e63a2633252fdbced58d2a9a87e2cdb34cf665b250317245ddc6a",
     );
     assert_eq!(lc.head_height(), 858816);
@@ -214,7 +214,7 @@ fun insert_header_happy_cases() {
     //     "nonce": "80f1e351"
     // }
     let headers = vector[
-        new_block_header(
+        header::new(
             x"00801e31c24ae25304cbac7c3d3b076e241abb20ff2da1d3ddfc00000000000000000000530e6745eca48e937428b0f15669efdce807a071703ed5a4df0e85a3f6cc0f601c35cf665b25031780f1e351",
         ),
     ];
@@ -232,7 +232,7 @@ fun insert_header_happy_cases() {
     //     "difficulty_target": "5b250317",
     //     "nonce": "807427ca"
     // }
-    let last_block_header = new_block_header(
+    let last_block_header = header::new(
         x"0040a320aa52a8971f61e56bf5a45117e3e224eabfef9237cb9a0100000000000000000060a9a5edd4e39b70ee803e3d22673799ae6ec733ea7549442324f9e3a790e4e4b806e1665b250317807427ca",
     );
     let last_block = new_light_block(
@@ -251,7 +251,7 @@ fun insert_header_happy_cases() {
     //     "nonce": "16c80c0d"
     // }
     let headers = vector[
-        new_block_header(
+        header::new(
             x"006089239c7c45da6d872c93dc9e8389d52b04bdd0a824eb308002000000000000000000fb4c3ac894ebc99c7a7b76ded35ec1c719907320ab781689ba1dedca40c5a9d7c50de1668c09031716c80c0d",
         ),
     ];
@@ -281,7 +281,7 @@ fun insert_headers_that_dont_from_a_chain_should_fail() {
     //     "difficulty_target": "5b250317",
     //     "nonce": "80f1e351"
     // }
-    let h = new_block_header(
+    let h = header::new(
         x"00801e31c24ae25304cbac7c3d3b076e241abb20ff2da1d3ddfc00000000000000000000530e6745eca48e937428b0f15669efdce807a071703ed5a4df0e85a3f6cc0f601c35cf665b25031780f1e351",
     );
     // we insert 2 identical headers.
@@ -298,7 +298,7 @@ fun insert_header_block_hash_not_match_should_fail() {
     // we changed the previous block hash to make the new header's previous hash not match with last hash
     // from: c24ae25304cbac7c3d3b076e241abb20ff2da1d3ddfc00000000000000000000
     // to:   c24ae25304cbac7c3d3b076e241abb20ff2da1d3ddfc00000000000000000001
-    let new_header = new_block_header(
+    let new_header = header::new(
         x"00801e31c24ae25304cbac7c3d3b076e241abb20ff2da1d3ddfc00000000000000000001530e6745eca48e937428b0f15669efdce807a071703ed5a4df0e85a3f6cc0f601c35cf665b25031780f1e351",
     );
     let h = *lc.head();
@@ -313,7 +313,7 @@ fun insert_header_failed_difficulty_not_match_should_fail() {
     let mut lc = new_lc_for_test(scenario.ctx());
     // we changed the difficulty to make the new header's previous hash not match with last hash
     // from 5b250317 to 5b250318
-    let new_header = new_block_header(
+    let new_header = header::new(
         x"00801e31c24ae25304cbac7c3d3b076e241abb20ff2da1d3ddfc00000000000000000000530e6745eca48e937428b0f15669efdce807a071703ed5a4df0e85a3f6cc0f601c35cf665b25031880f1e351",
     );
     let h = *lc.head();
@@ -327,7 +327,7 @@ fun insert_header_failed_timestamp_too_old_should_fail() {
     let mut scenario = test_scenario::begin(sender);
     let mut lc = new_lc_for_test(scenario.ctx());
     // we changed timestamp from 1c35cf66 to 0c35cf46
-    let new_header = new_block_header(
+    let new_header = header::new(
         x"00801e31c24ae25304cbac7c3d3b076e241abb20ff2da1d3ddfc00000000000000000000530e6745eca48e937428b0f15669efdce807a071703ed5a4df0e85a3f6cc0f600c35cf465b25031780f1e351",
     );
     let h = *lc.head();

--- a/packages/bitcoin_spv/tests/tx_verification_tests.move
+++ b/packages/bitcoin_spv/tests/tx_verification_tests.move
@@ -3,9 +3,9 @@
 #[test_only]
 module bitcoin_spv::tx_verification_tests;
 
-use bitcoin_spv::block_header::new_block_header;
 use bitcoin_spv::light_client::{new_light_client, LightClient};
 use bitcoin_spv::params;
+use btc_parser::header;
 use std::unit_test::assert_eq;
 use sui::test_scenario;
 
@@ -15,7 +15,7 @@ fun new_lc_for_test(ctx: &mut TxContext): LightClient {
     let headers = vector[
         x"01000000acda3db591d5c2c63e8c09e7523a5b0581707ef3e3520d6ca180000000000000701179cb9a9e0fe709cc96261b6b943b31362b61dacba94b03f9b71a06cc2eff7d1c1b4d4c86041b75962f88",
         x"010000007cb25d910aa274ad3e520e80e1e37440a7a2914b34ccd827f806030000000000fae45c19a095c8c796acf7a07257822f4e3c42c9d2ce513ceabc0188c041b6f8a21c1b4d4c86041be1dc4463",
-    ].map!(|h| new_block_header(h));
+    ].map!(|h| header::new(h));
     // finality=1 => block is "final" after one confirmation.
     new_light_client(params::mainnet(), start_block, headers, 0, 1, ctx)
 }

--- a/packages/btc_parser/Move.toml
+++ b/packages/btc_parser/Move.toml
@@ -11,7 +11,6 @@ edition = "2024.beta" # edition = "legacy" to use legacy (pre-2024) Move
 # MyRemotePackage = { git = "https://some.remote/host.git", subdir = "remote/path", rev = "main" }
 
 # For local dependencies use `local = path`. Path is relative to the package root
-# Local = { local = "../path/to" }
 
 # To resolve a version conflict and force a specific version for dependency
 # override use `override = true`

--- a/packages/btc_parser/sources/block_header.move
+++ b/packages/btc_parser/sources/block_header.move
@@ -5,16 +5,27 @@ module btc_parser::header;
 use btc_parser::crypto::hash256;
 use btc_parser::reader;
 
+// === Constants ===
+const BLOCK_HEADER_SIZE: u64 = 80;
+
+#[error]
+const EInvalidBlockHeaderSize: vector<u8> = b"The block header must be exactly 80 bytes long";
+
 public struct BlockHeader has copy, drop, store {
     version: u32,
     parent: vector<u8>,
     merkle_root: vector<u8>,
     timestamp: u32,
     bits: u32,
+    nonce: u32,
     block_hash: vector<u8>,
 }
 
+// === Block header methods ===
+
+/// New block header
 public fun new(raw_block_header: vector<u8>): BlockHeader {
+    assert!(raw_block_header.length() == BLOCK_HEADER_SIZE, EInvalidBlockHeaderSize);
     let mut r = reader::new(raw_block_header);
     BlockHeader {
         version: r.read_u32(),
@@ -22,10 +33,36 @@ public fun new(raw_block_header: vector<u8>): BlockHeader {
         merkle_root: r.read(32),
         timestamp: r.read_u32(),
         bits: r.read_u32(),
+        nonce: r.read_u32(),
         block_hash: hash256(raw_block_header),
     }
 }
 
-public fun block_hash(h: &BlockHeader): vector<u8> {
-    h.block_hash
+public fun block_hash(header: &BlockHeader): vector<u8> {
+    header.block_hash
+}
+
+public fun version(header: &BlockHeader): u32 {
+    header.version
+}
+
+/// return parent block ID (hash)
+public fun parent(header: &BlockHeader): vector<u8> {
+    header.parent
+}
+
+public fun merkle_root(header: &BlockHeader): vector<u8> {
+    header.merkle_root
+}
+
+public fun timestamp(header: &BlockHeader): u32 {
+    header.timestamp
+}
+
+public fun bits(header: &BlockHeader): u32 {
+    header.bits
+}
+
+public fun nonce(header: &BlockHeader): u32 {
+    header.nonce
 }

--- a/packages/btc_parser/tests/header_tests.move
+++ b/packages/btc_parser/tests/header_tests.move
@@ -1,0 +1,44 @@
+#[test_only]
+module btc_parser::header_tests;
+
+use btc_parser::encoding::u32_to_le_bytes;
+use btc_parser::header::{new, EInvalidBlockHeaderSize};
+use std::unit_test::assert_eq;
+
+#[test]
+fun block_header_happy_case() {
+    // data get from block 0000000000000000000293bf6e86820d867cc4ca13cd98326af85bb3bebab9ac from mainnet
+    // or block 794143
+    let raw_header =
+        x"000080200e102b98a160f4416c8ff0198db9b177523525c9de8a000000000000000000003b9b941003024e1afa90199732fdb1366a122ab0a5cacd3f7bcb8cb8815a811b560e8864697e051767c0c9fd";
+    let header = new(raw_header);
+
+    // verify data extract from header
+    assert_eq!(u32_to_le_bytes(header.version()), x"00008020");
+    assert_eq!(
+        header.parent(),
+        x"0e102b98a160f4416c8ff0198db9b177523525c9de8a00000000000000000000",
+    );
+    assert_eq!(
+        header.merkle_root(),
+        x"3b9b941003024e1afa90199732fdb1366a122ab0a5cacd3f7bcb8cb8815a811b",
+    );
+    assert_eq!(u32_to_le_bytes(header.timestamp()), x"560e8864");
+    assert_eq!(u32_to_le_bytes(header.bits()), x"697e0517");
+    assert_eq!(u32_to_le_bytes(header.nonce()), x"67c0c9fd");
+    assert_eq!(
+        header.block_hash(),
+        x"acb9babeb35bf86a3298cd13cac47c860d82866ebf9302000000000000000000",
+    );
+}
+#[test, expected_failure(abort_code = EInvalidBlockHeaderSize)]
+fun block_header_size_too_short_should_fail() {
+    new(x"0123456789abcdef");
+}
+
+#[test, expected_failure(abort_code = EInvalidBlockHeaderSize)]
+fun block_header_size_too_long_should_fail() {
+    new(
+        x"0100000000000000000000000000000000000000000000000000000000000000000000003ba3edfd7a7b12b27ac72c3e67768f617fc81bc3888a51323a9fb8aa4b1e5e4a29ab5f49ffff001d00000000ffff",
+    );
+}


### PR DESCRIPTION
## Description

Closes: #136 

---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
    <!-- * `feat`: A new feature
    * `fix`: A bug fix
    * `docs`: Documentation only changes
    * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
    * `refactor`: A code change that neither fixes a bug nor adds a feature
    * `perf`: A code change that improves performance
    * `test`: Adding missing tests or correcting existing tests
    * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
    * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
    * `chore`: Other changes that don't modify src or test files
    * `revert`: Reverts a previous commit -->
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] added appropriate labels to the PR
- [ ] provided a link to the relevant issue or specification
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included doc comments for public functions
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary

## Summary by Sourcery

Unify block header parsing by migrating implementation into btc_parser, remove duplicate code from bitcoin_spv, update imports, method aliases, and tests to use the new shared BlockHeader API

New Features:
- Introduce BlockHeader struct and parsing logic in btc_parser with size validation and field accessors
- Add header_tests in btc_parser to validate parsing and error conditions

Enhancements:
- Remove duplicate block header parsing code from bitcoin_spv and delegate to btc_parser
- Alias calc_work, pow_check, and target functions as methods on BlockHeader
- Update imports and Move.toml to integrate btc_parser dependency in bitcoin_spv

Tests:
- Refactor existing bitcoin_spv tests to use btc_parser::header::new instead of new_block_header