### PR TITLE
feat: update the dependecies and publishing scirpts

### DIFF
--- a/packages/bitcoin_spv/sources/light_block.move
+++ b/packages/bitcoin_spv/sources/light_block.move
@@ -2,7 +2,7 @@
 
 module bitcoin_spv::light_block;
 
-use bitcoin_spv::header::BlockHeader;
+use bitcoin_parser::header::BlockHeader;
 
 public struct LightBlock has copy, drop, store {
     height: u64,

--- a/scripts/SETUP.md
+++ b/scripts/SETUP.md
@@ -18,12 +18,12 @@ npm install
     sui client publish
     ```
 
-2.  **Configure your environment.** Create a `.env` file (see the example below) and populate it. Ensure the `PACKAGE_ID` and `NETWORK` match the publish output.
+2.  **Configure your environment.** Create a `.env` file (see the example below) and populate it. Ensure the `SPV_PACKAGE_ID`, `PARSER_PACKAGE_ID` and `NETWORK` match the publish output.
 
 3.  **Run the script** to create the light client object on-chain.
 
     ```bash
-    node new_light_client.js
+    bun new_light_client.js
     ```
 
 ---
@@ -35,7 +35,10 @@ npm install
 MNEMONIC='word1 word2 word3 ...'
 
 # ID of the deployed light client package
-PACKAGE_ID='0x...'
+SPV_PACKAGE_ID='0x...'
+
+# ID of the deployed bitcoin parser package
+PARSER_PACKAGE_ID='0x...'
 
 # Sui network alias ('mainnet', 'testnet', 'devnet', 'localnet')
 NETWORK='testnet'

--- a/scripts/new_light_client.js
+++ b/scripts/new_light_client.js
@@ -19,7 +19,8 @@ function mkSigner() {
 }
 
 async function main() {
-	const PACKAGE_ID = process.env.PACKAGE_ID;
+	const SPV_PACKAGE_ID = process.env.SPV_PACKAGE_ID;
+	const PARSER_PACKAGE_ID = process.env.PARSER_PACKAGE_ID;
 	const client = new SuiClient({ url: getFullnodeUrl(process.env.NETWORK) });
 
 	const signer = mkSigner();
@@ -28,25 +29,25 @@ async function main() {
 	let headers = [];
 	for (let i = 0; i < raw_headers.length; ++i) {
 		const header = tx.moveCall({
-			target: `${PACKAGE_ID}::block_header::new_block_header`,
+			target: `${PARSER_PACKAGE_ID}::header::new`,
 			arguments: [tx.pure("vector<u8>", fromHex(raw_headers[i]))],
 		});
 		headers.push(header);
 	}
 
 	const header_vec = tx.makeMoveVec({
-		type: `${PACKAGE_ID}::block_header::BlockHeader`,
+		type: `${PARSER_PACKAGE_ID}::header::BlockHeader`,
 		elements: headers,
 	});
 
 	tx.moveCall({
-		target: `${PACKAGE_ID}::light_client::initialize_light_client`,
+		target: `${SPV_PACKAGE_ID}::light_client::initialize_light_client`,
 		arguments: [
 			tx.pure.u8(process.env.BTC_NETWORK),
 			tx.pure.u64(process.env.BTC_HEIGHT),
 			header_vec,
 			tx.pure.u256(process.env.PARENT_CHAIN_WORK),
-			tx.pure.u64(process.env.FINALITY),
+			tx.pure.u64(process.env.CONFIRMATION_DEPTH),
 		],
 	});
 


### PR DESCRIPTION
## Description

Closes: #XXXX

---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
  <!-- * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit -->
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] added appropriate labels to the PR
- [ ] provided a link to the relevant issue or specification
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included doc comments for public functions
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary

## Summary by Sourcery

Refactor light client setup to support separate SPV and parser packages by updating scripts, environment variables, and Move imports

Enhancements:
- Introduce SPV_PACKAGE_ID and PARSER_PACKAGE_ID environment variables in scripts replacing the single PACKAGE_ID
- Rename FINALITY env variable to CONFIRMATION_DEPTH for clarity
- Update new_light_client.js to use separate package IDs for parser and SPV targets

Documentation:
- Revise SETUP.md to include SPV_PACKAGE_ID and PARSER_PACKAGE_ID configuration and switch the script runner from node to bun

Chores:
- Update Move module import to reference bitcoin_parser::header::BlockHeader instead of bitcoin_spv::header::BlockHeader